### PR TITLE
dockerSetting - volume naming

### DIFF
--- a/mariadb/Makefile
+++ b/mariadb/Makefile
@@ -14,8 +14,8 @@ COMPOSE_FILES := -f docker-compose.${PROFILE}.yml
 
 up:
 	# 실행된 명령어
-	# docker-compose ${COMPOSE_FILES} up
-	@docker-compose ${COMPOSE_FILES} up
+	# docker-compose ${COMPOSE_FILES} up -d
+	@docker-compose ${COMPOSE_FILES} up -d
 
 down:
 	@docker-compose ${COMPOSE_FILES} down --rmi all

--- a/mariadb/docker-compose.dev.yml
+++ b/mariadb/docker-compose.dev.yml
@@ -13,8 +13,15 @@ services:
     volumes:
       # docker-entrypoint-initdb.d 폴더에 있는 sql 파일을 자동으로 실행시킨다. 
       # 그래서 ./config/ 폴더에 sql 파일을 넣어두면 컨테이너가 실행될 때 자동으로 실행된다.
-      - ./config/:/docker-entrypoint-initdb.d
-    command: 
+      - ./config/setDB.sql:/docker-entrypoint-initdb.d/setDB.sql
+      - db_data:/var/lib/mysql
+#      - ./config/:/docker-entrypoint-initdb.d
+    command:
       --character-set-server=utf8mb4 
       --collation-server=utf8mb4_unicode_ci
       --default-time-zone='+9:00'
+
+# volumes는 서로 다른 컨테이너들이 하나의 volume을 공유
+volumes:
+#  db_init:
+  db_data:


### PR DESCRIPTION
##💁‍♂️설명
mariaDB컨테이너의 /var/lib/mysql는 데이터를 저장하는 위치입니다.
위 경로는 컨테이너 생성 시 기본 볼륨으로 생성됩니다. 새로운 컨테이너를 빌드하면 같은 경로의 또 다른 volume이 생성됩니다.
volume이 계속 생성되면 용량을 잡아먹습니다.
docker-compose에서 해당 경로를 volume으로 정의하면 컨테이너를 올릴 때 재생성되지 존재하던 volume을 참조합니다.

##🔗연결된 이슈
 x

##✅체크리스트
> db_data 이름으로 컨테이너의 /var/lib/mysql를 볼륨으로 지정
> make up 에 -d옵션을 주어 백그라운드 실행으로 변경
docker-compose ${COMPOSE_FILES} up -> docker-compose ${COMPOSE_FILES} up -d

##🚨주의사항
 x
